### PR TITLE
Add config paths to specify webpack config file and command-line opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ name, update your `config/application.rb` file:
 config.webpack_build_path = 'app/assets/javascripts/your-js-file.js'
 ````
 
+If you want to use a different webpack config file for a specific environment,
+such as `development`, update your `config/environment/development.rb` and
+specify the path to the config with `config.webpack_config_path`.
+
+````ruby
+# config/environments/development.rb
+config.webpack_config_path = 'webpack.dev.config.js'
+````
+
+Specify webpack command-line options with `config.webpack_opts`.
+The default is `--watch --devtool inline-source-map`.
+
+````ruby
+# config/environments.development.rb
+config.webpack_opts = '--watch --devtool inline-source-map'
+````
+
 Including the gem will automatically inject the webpack build into the
 precompilation of assets. To run your webpack build manually execute:
 

--- a/lib/webpack_assets/railtie.rb
+++ b/lib/webpack_assets/railtie.rb
@@ -6,7 +6,7 @@ module WebpackAssets
     end
 
     generators do
-     require 'webpack_assets/generators/init.rb'
+      require 'webpack_assets/generators/init.rb'
     end
 
   end

--- a/lib/webpack_assets/tasks/webpack.rake
+++ b/lib/webpack_assets/tasks/webpack.rake
@@ -30,10 +30,13 @@ namespace :assets do
     rm_rf path
   end
 
+  config  = 'webpack.config.js'                   unless Rails.application.config.try(:webpack_config_path)
+  opts    = '--watch --devtool inline-source-map' unless Rails.application.config.try(:webpack_opts)
+
   namespace :webpack do
     desc 'compile with webpack and watch for changes'
     task :watch do
-      sh "NODE_ENV=#{Rails.env} $(npm bin)/webpack --config webpack.config.js --watch --devtool inline-source-map"
+      sh "NODE_ENV=#{Rails.env} $(npm bin)/webpack --config #{config} #{opts}"
     end
   end
 


### PR DESCRIPTION
I'll be using `webpack_assets` on a project soon and I found that I need different webpack configs for different environments, so here's a PR to add that functionality.

Please let me know what you think!
