### PR TITLE
Add ability to manage multiple build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ name, update your `config/application.rb` file:
 config.webpack_build_path = 'app/assets/javascripts/your-js-file.js'
 ````
 
+For multiple files an array may be used:
+
+````ruby
+# config/application.rb
+config.webpack_build_path = [
+  'app/assets/javascripts/your-js-file1.js',
+  'app/assets/javascripts/your-js-file2.js',
+  'app/assets/javascripts/your-js-file3.js'
+]
+````
+
 Including the gem will automatically inject the webpack build into the
 precompilation of assets. To run your webpack build manually execute:
 

--- a/lib/webpack_assets/tasks/webpack.rake
+++ b/lib/webpack_assets/tasks/webpack.rake
@@ -18,21 +18,22 @@ namespace :assets do
     sh "NODE_ENV=#{Rails.env} $(npm bin)/webpack"
   end
 
-  # look up the file to clobber, or fallback to default
-  task :clobber do
-    path = begin
-            "#{Rails.root}/#{Rails.application.config.webpack_build_path}"
-           rescue
-            "#{Rails.root}/app/assets/javascripts/bundle.js"
-           end
-    rm_rf path
-  end
-
   namespace :webpack do
     desc 'compile with webpack and watch for changes'
     task :watch do
       sh "NODE_ENV=#{Rails.env} $(npm bin)/webpack --config webpack.config.js --colors --progress --watch --devtool inline-source-map"
     end
+
+    # look up the file to clobber, or fallback to default
+    task :clobber do
+      path = begin
+              [Rails.application.config.webpack_build_path].flatten.map { |path| "#{Rails.root}/#{path}" }
+             rescue
+              "#{Rails.root}/app/assets/javascripts/bundle.js"
+             end
+    rm_rf path
+  end
+
   end
 
 end

--- a/lib/webpack_assets/version.rb
+++ b/lib/webpack_assets/version.rb
@@ -1,3 +1,3 @@
 module WebpackAssets
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Additionally, the assets:clobber rake task interfes with the rails
predefined assets:clobber task so I moved the clobber task into the
assets:webpack namespace.
